### PR TITLE
Respond with 404 if user tries to GET a specific resource by id that doesn't exist

### DIFF
--- a/categories/request.py
+++ b/categories/request.py
@@ -32,8 +32,12 @@ def get_single_category(id):
         WHERE c.id = ?    
         """, (id, ))    
         row = db_cursor.fetchone()
-        category = Category(row['id'], row['name'])
-        return json.dumps(category.__dict__)
+
+        if row:
+            category = Category(row['id'], row['name'])
+            return json.dumps(category.__dict__)
+        else:
+            return False
 
 def create_category(category):
     with sqlite3.connect("./rare.db") as conn:

--- a/tags/request.py
+++ b/tags/request.py
@@ -32,8 +32,12 @@ def get_single_tag(id):
         WHERE t.id = ?    
         """, (id, ))    
         row = db_cursor.fetchone()
-        tag = Tag(row['id'], row['name'])
-        return json.dumps(tag.__dict__)
+
+        if row:
+            tag = Tag(row['id'], row['name'])
+            return json.dumps(tag.__dict__)
+        else:
+            return False
 
 def create_tag(tag):
     with sqlite3.connect("./rare.db") as conn:

--- a/users/request.py
+++ b/users/request.py
@@ -3,13 +3,9 @@ import json
 from models import User
 
 def get_all_users():
-   
     with sqlite3.connect("./rare.db") as conn:
-
-        
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
-
         
         db_cursor.execute("""
         SELECT
@@ -21,20 +17,14 @@ def get_all_users():
             u.password
         FROM User u
         """)
-
         
         users = []
-
         
         dataset = db_cursor.fetchall()
-
        
         for row in dataset:
-
-            
             user = User(row['id'], row['first_name'], row['last_name'], row['username'],
                     row['email'], row['password'])
-
 
             users.append(user.__dict__)
 
@@ -54,13 +44,10 @@ def create_user(new_user):
         """, (new_user['first_name'], new_user['last_name'],
               new_user['username'], new_user['email'],
               new_user['password'], ))
-
         
         id = db_cursor.lastrowid
-
         
         new_user['id'] = id
-
 
     return json.dumps(new_user)
 
@@ -68,7 +55,6 @@ def get_single_user(id):
     with sqlite3.connect("./rare.db") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
-
         
         db_cursor.execute("""
         SELECT
@@ -81,15 +67,13 @@ def get_single_user(id):
         FROM User u
         WHERE u.id = ?
         """, ( id, ))
-
         
         data = db_cursor.fetchone()
-
         
-        user = User(data['id'], data['first_name'], data['last_name'], data['username'],
-                    data['email'], data['password'])
+        if data:
+            user = User(data['id'], data['first_name'], data['last_name'], data['username'],
+                        data['email'], data['password'])
         
-
-        
-
-        return json.dumps(user.__dict__)
+            return json.dumps(user.__dict__)
+        else:
+            return False


### PR DESCRIPTION
# Description
If any `get_*` function hooked up as a GET handler for a specific resource returns False, `request_handler.py` interprets that to mean it should send a 404 response to the client. This PR returns False for categories, tags, and users `request.py` files for that case.

Fixes #85 (on the client project board)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Make GET requests in Postman to `/users/0`, `/tags/0`, and `/categories/0` and verify that you get a 404 response.
- [ ] Make GET requests in Postman for specific user by id, tag by id, and category by id for data that exists in your database, and confirm that the response is 200 in that case and you get the data you crave.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings